### PR TITLE
test: write a simple suite test

### DIFF
--- a/config/crd/bases/batch.grasse.io_cronsets.yaml
+++ b/config/crd/bases/batch.grasse.io_cronsets.yaml
@@ -2671,7 +2671,9 @@ spec:
                                                     - name
                                                     type: object
                                                   type: array
-                                                  x-kubernetes-list-type: set
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
                                                 limits:
                                                   additionalProperties:
                                                     anyOf:
@@ -4373,7 +4375,9 @@ spec:
                                                     - name
                                                     type: object
                                                   type: array
-                                                  x-kubernetes-list-type: set
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
                                                 limits:
                                                   additionalProperties:
                                                     anyOf:
@@ -6117,7 +6121,9 @@ spec:
                                                     - name
                                                     type: object
                                                   type: array
-                                                  x-kubernetes-list-type: set
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
                                                 limits:
                                                   additionalProperties:
                                                     anyOf:
@@ -8387,7 +8393,9 @@ spec:
                                                                 - name
                                                                 type: object
                                                               type: array
-                                                              x-kubernetes-list-type: set
+                                                              x-kubernetes-list-map-keys:
+                                                              - name
+                                                              x-kubernetes-list-type: map
                                                             limits:
                                                               additionalProperties:
                                                                 anyOf:

--- a/controllers/cronset_controller.go
+++ b/controllers/cronset_controller.go
@@ -18,7 +18,7 @@ package controllers
 
 import (
 	"context"
-
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,9 +47,25 @@ type CronSetReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *CronSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	log := log.FromContext(ctx)
+
+	log.Info("Reconcile")
 
 	// TODO(user): your logic here
+	obj := &batchv1alpha1.CronSet{}
+	err := r.Get(ctx, req.NamespacedName, obj)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// for testing
+	log.Info(obj.GetObjectKind().GroupVersionKind().Group)
+	log.Info(obj.GetObjectKind().GroupVersionKind().Version)
+	log.Info(obj.GetObjectKind().GroupVersionKind().Kind)
+
+	fmt.Println(obj.GetObjectKind().GroupVersionKind().Group)
+	fmt.Println(obj.GetObjectKind().GroupVersionKind().Version)
+	fmt.Println(obj.GetObjectKind().GroupVersionKind().Kind)
 
 	return ctrl.Result{}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.19
 require (
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
-	k8s.io/apimachinery v0.26.0
+	k8s.io/api v0.26.1
+	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.0
 	sigs.k8s.io/controller-runtime v0.14.1
 )
@@ -58,7 +59,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.26.0 // indirect
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/component-base v0.26.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -588,10 +588,14 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.26.0 h1:IpPlZnxBpV1xl7TGk/X6lFtpgjgntCg8PJ+qrPHAC7I=
 k8s.io/api v0.26.0/go.mod h1:k6HDTaIFC8yn1i6pSClSqIwLABIcLV9l5Q4EcngKnQg=
+k8s.io/api v0.26.1 h1:f+SWYiPd/GsiWwVRz+NbFyCgvv75Pk9NK6dlkZgpCRQ=
+k8s.io/api v0.26.1/go.mod h1:xd/GBNgR0f707+ATNyPmQ1oyKSgndzXij81FzWGsejg=
 k8s.io/apiextensions-apiserver v0.26.0 h1:Gy93Xo1eg2ZIkNX/8vy5xviVSxwQulsnUdQ00nEdpDo=
 k8s.io/apiextensions-apiserver v0.26.0/go.mod h1:7ez0LTiyW5nq3vADtK6C3kMESxadD51Bh6uz3JOlqWQ=
 k8s.io/apimachinery v0.26.0 h1:1feANjElT7MvPqp0JT6F3Ss6TWDwmcjLypwoPpEf7zg=
 k8s.io/apimachinery v0.26.0/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
+k8s.io/apimachinery v0.26.1 h1:8EZ/eGJL+hY/MYCNwhmDzVqq2lPl3N3Bo8rvweJwXUQ=
+k8s.io/apimachinery v0.26.1/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
 k8s.io/client-go v0.26.0 h1:lT1D3OfO+wIi9UFolCrifbjUUgu7CpLca0AD8ghRLI8=
 k8s.io/client-go v0.26.0/go.mod h1:I2Sh57A79EQsDmn7F7ASpmru1cceh3ocVT9KlX2jEZg=
 k8s.io/component-base v0.26.0 h1:0IkChOCohtDHttmKuz+EP3j3+qKmV55rM9gIFTXA7Vs=


### PR DESCRIPTION
Write a simple suite test to verify the behavior of the reconcile method.
Also, upgrade the version of k8s.io/api to v0.26.1.
Please refer to [this issue](https://github.com/kubernetes-sigs/kubebuilder/issues/3303).

The following prerequisites are required to run the test:

1. make envtest
2. ./bin/setup-envtest use --bin-dir ./testbin 1.26.1 