### PR TITLE
fix: modify fields in cronsetspec

### DIFF
--- a/api/v1alpha1/cronset_types.go
+++ b/api/v1alpha1/cronset_types.go
@@ -40,7 +40,7 @@ type CronJobTemplateSpec struct {
 type CronSetSpec struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,1,opt,name=selector"`
 
-	CronJobTemplate CronJobTemplateSpec `json:"template,omitempty" protobuf:"bytes,2,opt,name=template"`
+	CronJobTemplate CronJobTemplateSpec `json:"cronJobTemplate,omitempty" protobuf:"bytes,2,opt,name=cronJobTemplate"`
 }
 
 // CronSetStatus defines the observed state of CronSet

--- a/api/v1alpha1/cronset_types.go
+++ b/api/v1alpha1/cronset_types.go
@@ -38,9 +38,9 @@ type CronJobTemplateSpec struct {
 
 // CronSetSpec defines the desired state of CronSet
 type CronSetSpec struct {
-	Selector *metav1.LabelSelector `json:"selector" protobuf:"bytes,1,opt,name=selector"`
+	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,1,opt,name=selector"`
 
-	CronJobTemplate CronJobTemplateSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=cronJobTemplate"`
+	CronJobTemplate CronJobTemplateSpec `json:"template,omitempty" protobuf:"bytes,2,opt,name=template"`
 }
 
 // CronSetStatus defines the observed state of CronSet

--- a/config/crd/bases/batch.grasse.io_cronsets.yaml
+++ b/config/crd/bases/batch.grasse.io_cronsets.yaml
@@ -83,7 +83,7 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              spec:
+              template:
                 properties:
                   metadata:
                     description: 'Standard object''s metadata of the jobs created
@@ -9825,8 +9825,6 @@ spec:
                     - schedule
                     type: object
                 type: object
-            required:
-            - selector
             type: object
           status:
             description: CronSetStatus defines the observed state of CronSet

--- a/config/crd/bases/batch.grasse.io_cronsets.yaml
+++ b/config/crd/bases/batch.grasse.io_cronsets.yaml
@@ -35,55 +35,7 @@ spec:
           spec:
             description: CronSetSpec defines the desired state of CronSet
             properties:
-              selector:
-                description: A label selector is a label query over a set of resources.
-                  The result of matchLabels and matchExpressions are ANDed. An empty
-                  label selector matches all objects. A null label selector matches
-                  no objects.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
-                          type: string
-                        values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
-                    type: object
-                type: object
-                x-kubernetes-map-type: atomic
-              template:
+              cronJobTemplate:
                 properties:
                   metadata:
                     description: 'Standard object''s metadata of the jobs created
@@ -9825,6 +9777,54 @@ spec:
                     - schedule
                     type: object
                 type: object
+              selector:
+                description: A label selector is a label query over a set of resources.
+                  The result of matchLabels and matchExpressions are ANDed. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
             type: object
           status:
             description: CronSetStatus defines the observed state of CronSet

--- a/config/samples/batch_v1alpha1_cronset.yaml
+++ b/config/samples/batch_v1alpha1_cronset.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/created-by: cron-set-controller
   name: cronset-sample
 spec:
-  template:
+  cronJobTemplate:
     spec:
       schedule: "*/1 * * * *"
       jobTemplate:

--- a/config/samples/batch_v1alpha1_cronset.yaml
+++ b/config/samples/batch_v1alpha1_cronset.yaml
@@ -9,4 +9,14 @@ metadata:
     app.kubernetes.io/created-by: cron-set-controller
   name: cronset-sample
 spec:
-  # TODO(user): Add fields here
+  template:
+    spec:
+      schedule: "*/1 * * * *"
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - name: test-container-1
+                  image: alpine
+              restartPolicy: OnFailure


### PR DESCRIPTION
The field settings in the CronSetSpec are modified.
- Selector is not mandatory, so we need to add the omitempty property.
- Rename CronJobTemplate's json to ~template~ cronJobTemplate