### PR TITLE
chore: clean up code

### DIFF
--- a/controllers/cronset_controller.go
+++ b/controllers/cronset_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"github.com/go-logr/logr"
 	batchv1alpha1 "github.com/grasse-oss/cron-set-controller/api/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -56,8 +55,7 @@ type CronSetReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *CronSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Info("Reconcile")
-	fmt.Println("Reconcile -> {}", req)
+	r.Log.Info("Reconcile:", req.String())
 
 	// TODO(user): your logic here
 	obj := &batchv1alpha1.CronSet{}
@@ -67,15 +65,6 @@ func (r *CronSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		return ctrl.Result{}, err
 	}
-
-	// for testing
-	r.Log.Info(obj.GetObjectKind().GroupVersionKind().Group)
-	r.Log.Info(obj.GetObjectKind().GroupVersionKind().Version)
-	r.Log.Info(obj.GetObjectKind().GroupVersionKind().Kind)
-
-	fmt.Println(obj.GetObjectKind().GroupVersionKind().Group)
-	fmt.Println(obj.GetObjectKind().GroupVersionKind().Version)
-	fmt.Println(obj.GetObjectKind().GroupVersionKind().Kind)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -83,6 +83,7 @@ var _ = BeforeSuite(func() {
 
 	err = (&CronSetReconciler{
 		Client: k8sManager.GetClient(),
+		Log:    k8sManager.GetLogger(),
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -19,8 +19,6 @@ package main
 import (
 	"flag"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -92,7 +90,7 @@ func main() {
 
 	if err = (&controllers.CronSetReconciler{
 		Client: mgr.GetClient(),
-		Log:    log.Log.WithName("controllers").WithName("CronSet"),
+		Log:    ctrl.Log.WithName("controllers").WithName("CronSet"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CronSet")


### PR DESCRIPTION
Before implementing the reconcile method, clean up any unnecessary code.