### PR TITLE
feat: get the list of nodes

### DIFF
--- a/controllers/cronset_controller.go
+++ b/controllers/cronset_controller.go
@@ -71,7 +71,7 @@ func (r *CronSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		nodeSelector = obj.Spec.CronJobTemplate.Spec.JobTemplate.Spec.Template.Spec.NodeSelector
 	}
 	nodes := &corev1.NodeList{}
-	if err := r.Client.List(ctx, nodes, client.MatchingLabels(nodeSelector)); err != nil && errors.IsNotFound(err) {
+	if err := r.List(ctx, nodes, client.MatchingLabels(nodeSelector)); err != nil && errors.IsNotFound(err) {
 		return reconcile.Result{}, nil
 	}
 	nodeMap := make(map[string]bool)

--- a/controllers/cronset_controller.go
+++ b/controllers/cronset_controller.go
@@ -66,6 +66,19 @@ func (r *CronSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	var nodeSelector map[string]string
+	if obj.Spec.CronJobTemplate.Spec.JobTemplate.Spec.Template.Spec.NodeSelector != nil {
+		nodeSelector = obj.Spec.CronJobTemplate.Spec.JobTemplate.Spec.Template.Spec.NodeSelector
+	}
+	nodes := &corev1.NodeList{}
+	if err := r.Client.List(ctx, nodes, client.MatchingLabels(nodeSelector)); err != nil && errors.IsNotFound(err) {
+		return reconcile.Result{}, nil
+	}
+	nodeMap := make(map[string]bool)
+	for _, item := range nodes.Items {
+		nodeMap[item.Name] = true
+	}
+
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Get a list of nodes and save it as a map for later use.

Get the Nodes based on the nodeSelector of the Pod inside the CronSet passed to reconcile.Request. This avoids unnecessary Node traversal.