### PR TITLE
test(e2e): setup e2e tests using kuttl

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,0 +1,85 @@
+name: End-to=End Test
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  NAMESPACE: cron-set-controller-system
+
+jobs:
+  docs_only_check:
+    name: Check for docs-only change
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      docs_only: ${{ steps.docs_only_check.outputs.docs_only }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+      - id: changed-files
+        name: Get changed files
+        uses: tj-actions/changed-files@54849deb963ca9f24185fb5de2965e002d066e6b #v37.0.5
+        with:
+          files_ignore: |
+            **/*.md
+            **/*.pnd
+            **/*.txt
+      - id: which_files
+        name: Which files was changed
+        run: |
+          echo "One or more files has changed."
+          echo "List all the files that have changed: ${{ steps.changed-files.outputs.all_changed_files }}"
+          echo "What is any changed ${{ steps.changed-files.outputs.any_changed }}"
+      - id: docs_only_check
+        if: steps.changed-files.outputs.any_changed != 'true'
+        name: Check for docs-only changes
+        run: echo "docs_only=true" >> $GITHUB_OUTPUT
+
+  end-to-end:
+    runs-on: ubuntu-latest
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - uses: azure/setup-kubectl@v3
+    
+      - name: Set up KinD
+        id: kind
+        run: |
+          # create KinD cluster
+          make kind-cluster
+
+      - name: Build and load
+        env:
+          KO_DOCKER_REPO: ko.local/grasse/cronset
+        run: |
+          make docker-build-kind
+
+      - name: Run e2e
+        shell: bash
+        run: |
+          # install kuttl
+          make kuttl
+          # run e2e test
+          VERSION=latest make e2e
+
+      - name: Debug failure
+        if: failure()
+        run: |
+          kubectl version
+          kubectl -n get all
+          kubectl -n get cronset
+          kubectl get crd
+          POD=$(kubectl get pods -n $NAMESPACE -l control-plane=controller-manager --output=jsonpath={.items..metadata.name})
+          kubectl logs -n $NAMESPACE $POD -c manager

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,4 +1,4 @@
-name: End-to=End Test
+name: End-to-End Test
 
 on:
   pull_request:
@@ -52,7 +52,9 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - uses: azure/setup-kubectl@v3
+      - uses: ko-build/setup-ko@v0.6
+        with:
+          version: v0.13.0
     
       - name: Set up KinD
         id: kind
@@ -62,9 +64,10 @@ jobs:
 
       - name: Build and load
         env:
-          KO_DOCKER_REPO: ko.local/grasse/cronset
+          KO_DOCKER_REPO: ko.local/grasse/cronset-controller
         run: |
-          make docker-build-kind
+          ko build --sbom=none --bare
+          kind load docker-image "$KO_DOCKER_REPO"
 
       - name: Run e2e
         shell: bash
@@ -78,8 +81,8 @@ jobs:
         if: failure()
         run: |
           kubectl version
-          kubectl -n get all
-          kubectl -n get cronset
+          kubectl get all
+          kubectl get cronset
           kubectl get crd
           POD=$(kubectl get pods -n $NAMESPACE -l control-plane=controller-manager --output=jsonpath={.items..metadata.name})
           kubectl logs -n $NAMESPACE $POD -c manager

--- a/config/kuttl-overlay/deployment-patch.yaml
+++ b/config/kuttl-overlay/deployment-patch.yaml
@@ -8,3 +8,4 @@ spec:
       containers:
       - name: manager
         imagePullPolicy: Never
+        command: []

--- a/config/kuttl-overlay/deployment-patch.yaml
+++ b/config/kuttl-overlay/deployment-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: Never

--- a/config/kuttl-overlay/kustomization.yaml
+++ b/config/kuttl-overlay/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - ../default
+
+patches:
+  - path: deployment-patch.yaml
+    target:
+      group: apps
+      kind: Deployment
+      version: v1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+  - name: controller
+    newName: ko.local/grasse/cronset-controller
+    newTag: latest

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+startKIND: false
+suppress:
+  - events
+kindNodeCache: true
+skipClusterDelete: true
+namespace: default
+timeout: 120
+testDirs:
+  - ./tests/e2e/

--- a/tests/e2e/example-test/00-assert.yaml
+++ b/tests/e2e/example-test/00-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronset-sample-kind-control-plane-cronjob
+  namespace: default
+status: {}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronset-sample-kind-worker-cronjob
+  namespace: default
+status: {}

--- a/tests/e2e/example-test/00-create-cronset.yaml
+++ b/tests/e2e/example-test/00-create-cronset.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch.grasse.io/v1alpha1
+kind: CronSet
+metadata:
+  labels:
+    app.kubernetes.io/name: cronset
+    app.kubernetes.io/instance: cronset-sample
+    app.kubernetes.io/part-of: cron-set-controller
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: cron-set-controller
+  name: cronset-sample
+spec:
+  cronJobTemplate:
+    spec:
+      schedule: "*/1 * * * *"
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - name: test-container
+                  image: alpine
+              restartPolicy: OnFailure

--- a/tests/e2e/kind.yaml
+++ b/tests/e2e/kind.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker


### PR DESCRIPTION
It is based on the e2e testing approach of [grafana-operator](https://github.com/grafana-operator/grafana-operator/tree/master).

The e2e test for grafana-operator uses [ko](https://github.com/ko-build/ko) and [kuttl](https://github.com/kudobuilder/kuttl), but we don't need `ko` because we already have a Dockerfile written that creates the controller image.
So we only need to use `kuttl`.

`kuttl` seems to be a very handy tool for e2e: it provides not only [asserts](https://kuttl.dev/docs/testing/asserts-errors.html) to check status, but also [steps](https://kuttl.dev/docs/testing/steps.html), which allow us to raise variouse events.