### PR TITLE
fix(ctrl): modify to use NODE_IDENTIFICATION_KEY env to create name of cronjob

### DIFF
--- a/controllers/cronset_controller.go
+++ b/controllers/cronset_controller.go
@@ -203,7 +203,9 @@ func getNodeIdentifier(node *corev1.Node) string {
 	identificationKey := os.Getenv(NodeIdentificationKey)
 
 	if len(identificationKey) > 0 {
-		return node.Annotations[identificationKey]
+		if annotationValue, ok := node.Annotations[identificationKey]; ok {
+			return annotationValue
+		}
 	}
 
 	return node.Name

--- a/controllers/cronset_controller.go
+++ b/controllers/cronset_controller.go
@@ -201,13 +201,9 @@ func (r *CronSetReconciler) cleanUpCronJob(ctx context.Context, cronSetName stri
 
 func getNodeIdentifier(node *corev1.Node) string {
 	identificationKey := os.Getenv(NodeIdentificationKey)
-
-	if len(identificationKey) > 0 {
-		if annotationValue, ok := node.Annotations[identificationKey]; ok {
-			return annotationValue
-		}
+	if annotationValue, ok := node.Annotations[identificationKey]; ok {
+		return annotationValue
 	}
-
 	return node.Name
 }
 

--- a/controllers/cronset_controller_test.go
+++ b/controllers/cronset_controller_test.go
@@ -150,6 +150,22 @@ func (s *CronSetSuite) TestCronSetEvent_Create_CreateCronJob() {
 
 		os.Unsetenv(NodeIdentificationKey)
 	})
+
+	s.Run("When reconcile after creating a CronSet object with wrong NodeIdentificationKey Env", func() {
+		os.Setenv(NodeIdentificationKey, "abc")
+		_, err := s.reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: cronSetKey})
+		assert.NoError(s.T(), err)
+
+		s.Run("Should include node's name in the name of the generated cronjob.", func() {
+			createdCronJob := &batchv1.CronJob{}
+			err := s.fakeClient.Get(ctx, nodeCronJobKey, createdCronJob)
+			assert.NoError(s.T(), err)
+			assert.NotEmpty(s.T(), createdCronJob)
+			assert.Equal(s.T(), expectedOwnerRefs, createdCronJob.OwnerReferences)
+		})
+
+		os.Unsetenv(NodeIdentificationKey)
+	})
 }
 
 func (s *CronSetSuite) TestCronSetEvent_Update_UpdateCronJob() {

--- a/controllers/cronset_controller_test.go
+++ b/controllers/cronset_controller_test.go
@@ -147,6 +147,8 @@ func (s *CronSetSuite) TestCronSetEvent_Create_CreateCronJob() {
 			assert.NotEmpty(s.T(), createdCronJob)
 			assert.Equal(s.T(), expectedOwnerRefs, createdCronJob.OwnerReferences)
 		})
+
+		os.Unsetenv(NodeIdentificationKey)
 	})
 }
 

--- a/deploy/helm/cron-set-controller/templates/deployment.yaml
+++ b/deploy/helm/cron-set-controller/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - --v=0
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
-          value: cluster.local
+          value: {{ .Values.manager.env.KUBERNETES_CLUSTER_DOMAIN }}
         image: {{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag | default .Chart.AppVersion }}
         ports:
         - containerPort: {{ .Values.metricsService.port }}
@@ -50,10 +50,10 @@ spec:
         command:
         - /manager
         env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: cluster.local
-        - name: NODE_IDENTIFICATION_KEY
-          value: {{ .Values.manager.env.nodeIdentificationKey }}
+        {{- range $key, $value := .Values.manager.env }}
+        - name: {{ $key | quote }}
+          value: {{ tpl ( $value | quote ) $}}
+        {{- end }}
         image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}
         livenessProbe:
           httpGet:

--- a/deploy/helm/cron-set-controller/templates/deployment.yaml
+++ b/deploy/helm/cron-set-controller/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
+        - name: NODE_IDENTIFICATION_KEY
+          value: {{ .Values.manager.env.nodeIdentificationKey }}
         image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}
         livenessProbe:
           httpGet:

--- a/deploy/helm/cron-set-controller/values.yaml
+++ b/deploy/helm/cron-set-controller/values.yaml
@@ -37,9 +37,10 @@ manager:
       drop:
         - ALL
   env:
+    KUBERNETES_CLUSTER_DOMAIN: cluster.local
     # -- The key of the node's specific annotation to be used for the name when the cronjob is created
     # If not set, the node's name is used
-    nodeIdentificationKey: ""
+    NODE_IDENTIFICATION_KEY: ""
 
 metricsService:
   enabled: true

--- a/deploy/helm/cron-set-controller/values.yaml
+++ b/deploy/helm/cron-set-controller/values.yaml
@@ -36,6 +36,10 @@ manager:
     capabilities:
       drop:
         - ALL
+  env:
+    # -- The key of the node's specific annotation to be used for the name when the cronjob is created
+    # If not set, the node's name is used
+    nodeIdentificationKey: ""
 
 metricsService:
   enabled: true

--- a/tests/e2e/example-test/dependent-resources.yaml
+++ b/tests/e2e/example-test/dependent-resources.yaml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cronset-sample-kind-control-plane-cronjob
+  name: cronset-sample-kind-control-plane
   namespace: default
 status: {}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cronset-sample-kind-worker-cronjob
+  name: cronset-sample-kind-worker
   namespace: default
 status: {}


### PR DESCRIPTION
The name of the node is so long that the name of the generated cronjob also throws an error if it is longer than 52 characters.

To avoid this, we want to add the `NODE_IDENTIFICATION_KEY` env so that the name of the cronjob can be generated from the value of the annotation rather than the name of the node.

In an environment like this,

```go
CronSetName  = "test-cronset"

Node = corev1.Node{
	ObjectMeta: metav1.ObjectMeta{
		Name:        "test-node",
		Labels:      map[string]string{"foo": "bar"},
		Annotations: map[string]string{"xyz": "baz"},
	},
}
```

If the `NODE_IDENTIFICATION_KEY` is specified as xyz,
the cronjob created on that node will be named `test-cronset-baz` instead of `test-cronset-test-node`.