### PR TITLE
fix(list-notfound): remove checking notfound when listing

### DIFF
--- a/controllers/cronset_controller.go
+++ b/controllers/cronset_controller.go
@@ -136,6 +136,7 @@ func (r *CronSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	nodeList := &corev1.NodeList{}
 	nodeMap := make(map[string]bool)
 	if err := r.List(ctx, nodeList, client.MatchingLabels(nodeSelector)); err != nil {
+		r.Log.Error(err, "Failed to get node list")
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/cronset_controller.go
+++ b/controllers/cronset_controller.go
@@ -135,9 +135,8 @@ func (r *CronSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	nodeList := &corev1.NodeList{}
 	nodeMap := make(map[string]bool)
-	if err := r.List(ctx, nodeList, client.MatchingLabels(nodeSelector)); err != nil && errors.IsNotFound(err) {
-		r.Log.Info("No nodes matched the cronset settings.")
-		return reconcile.Result{}, nil
+	if err := r.List(ctx, nodeList, client.MatchingLabels(nodeSelector)); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	r.Log.Info("Matched", "node list", nodeList.Items)


### PR DESCRIPTION
- because `erros.IsNotFound` doesn't work when call list api and just return size 0 array