### PR TITLE
ci: support multi-arch image build and push to GHCR

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -10,22 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: grasse

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -10,28 +10,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '^1.25.0'
+          go-version-file: 'go.mod'
+          cache: true
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: grasse
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Generate Image Tag
         id: tag
         run: |
           TAG=$(echo "${{ github.ref }}" | sed 's/refs\/tags\///')
           IMAGE_VERSION=$(echo "$TAG" | sed 's/cron-set-controller-v//')
-
           IMAGE_TAG="ghcr.io/grasse-oss/cron-set-controller:${IMAGE_VERSION}"
-          echo "::set-output name=image_tag::${IMAGE_TAG}"
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Build and Push Image
-        run: |
-          echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u grasse --password-stdin
-          make docker-build docker-push IMG=${IMAGE_TAG}
-        env:
-          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tag.outputs.image_tag }}


### PR DESCRIPTION
This PR updates the image build workflow to support multi-architecture (amd64, arm64) builds and optimizes the CI process by using the latest GitHub Actions.